### PR TITLE
Missing parenthisis on line 254 of classes/ezjscserverfunctionsautosave.php

### DIFF
--- a/classes/ezjscserverfunctionsautosave.php
+++ b/classes/ezjscserverfunctionsautosave.php
@@ -251,7 +251,7 @@ class ezjscServerFunctionsAutosave extends ezjscServerFunctions
         $tpl->setVariable( 'version', $object->version( (int)$args[1] ) );
         $tpl->setVariable( 'locale', eZLocale::instance( $args[2] ) );
         $siteaccessList = self::getSiteaccessList( $args[2], $object );
-        if ( empty( $siteaccessList )
+        if ( empty( $siteaccessList ) )
         {
             $siteaccessList = array(
                 eZINI::instance( 'site.ini' )->variable(


### PR DESCRIPTION
While testing the latest changes in Fixed #19394: Choose the right siteaccess when previewing multilingual content I found this error.
