### PR TITLE
Fix EZP-20605: Redirected to the autosave action when publishing a content

### DIFF
--- a/design/standard/javascript/ezautosubmit.js
+++ b/design/standard/javascript/ezautosubmit.js
@@ -160,9 +160,11 @@ YUI(YUI3_config).add('ezautosubmit', function (Y) {
         var that = this,
             formState = serializeForm(this.conf.form, this.conf.ignoreClass),
             originalFormState = formState,
+            form = Y.one(this.conf.form),
+            originalFormAction = form.getAttribute('action'),
             ajaxConf = Y.clone(this.ajaxConfiguration, true);
 
-        ajaxConf.form.id = Y.one(this.conf.form);
+        ajaxConf.form.id = form;
         if ( !this.started ) {
             return;
         }
@@ -202,6 +204,12 @@ YUI(YUI3_config).add('ezautosubmit', function (Y) {
                 ajaxConf.data = fields;
             }
             this.ajax = Y.io(this.conf.action, ajaxConf);
+            // Workaround to http://yuilibrary.com/projects/yui3/ticket/2532899
+            // this and the declaration of the form and originalFormAction vars
+            // can be removed as soon as the YUI issue is fixed
+            form.setAttribute('action', originalFormAction);
+            form.removeAttribute('target');
+            // End workaround
         } else {
             this.fire('nochange');
         }


### PR DESCRIPTION
JIRA issue: https://jira.ez.no/browse/EZP-20605
# Description

If ezautosave is activated and an auto submit has been triggered to save the draft, clicking on any button that submits the form redirects you the autosave action or open a tab to it... This is due to this YUI3 issue http://yuilibrary.com/projects/yui3/ticket/2532899 (or http://yuilibrary.com/projects/yui3/ticket/2533186).

This patch adds a workaround to this YUI issue that makes sure the form is correctly restored.
# Tests

Manual tests in IE8, IE9, Firefox and Chrome
