### PR TITLE
fix for EZP-20826: replaced the $node variable by $object

### DIFF
--- a/design/admin2/templates/content/ajax_preview.tpl
+++ b/design/admin2/templates/content/ajax_preview.tpl
@@ -1,7 +1,7 @@
 <div class="preview-header">
     <h1 class="context-title">
         <a href="#" class="close">&laquo;&nbsp;{'Back to the edit form'|i18n( 'design/admin2/content/ajax_preview' )}</a>
-        {$object.content_class.identifier|class_icon( normal, $node.class_name )}
+        {$object.content_class.identifier|class_icon( 'normal', $object.class_name )}
         {'Preview of &lt;%name&gt; in siteaccess'|i18n( 'design/admin2/content/ajax_preview', '', hash( '%name', $version.name ) )}
         <select class="no-autosave">
         {foreach $siteaccess_list as $sa}


### PR DESCRIPTION
the $node variable is not passed to the template when autosaving a draft, throwing an error in the error.log
using the object variable instead fixed the problem

I also cleaned up the line putting quotes around the 'normal' parameter
