### PR TITLE
Fix EZP-21517: Drafts disappear from dashboard after being edited and resaved

### DIFF
--- a/classes/ezjscserverfunctionsautosave.php
+++ b/classes/ezjscserverfunctionsautosave.php
@@ -187,12 +187,9 @@ class ezjscServerFunctionsAutosave extends ezjscServerFunctions
         );
 
         $version->setAttribute( 'modified', time() );
-        $status = eZContentObjectVersion::STATUS_INTERNAL_DRAFT;
-        if ( $http->hasPostVariable( 'StoreExitButton' ) )
-        {
-            $status = eZContentObjectVersion::STATUS_DRAFT;
-        }
-        $version->setAttribute( 'status', $status );
+
+        // Do not use internal draft since it simulates the saving action
+        $version->setAttribute( 'status', eZContentObjectVersion::STATUS_DRAFT );
 
         $attributesToStore = array();
         foreach( $fetchResult['attribute-input-map'] as $id => $value )


### PR DESCRIPTION
# Description

Link: https://jira.ez.no/browse/EZP-21517

On some browsers (firefox seems to limit this effect) sometimes, the autosave request is processed after the regular save request.

Since autosave used to save the draft as an internal draft in most cases, that would make the draft disappear from the dashboard.

The proposed fix is for autosave to always save as a regular draft, exactly like if the user clicked on the save button, knowing that autosave is not triggered on an empty form, so it would not create stale drafts.
# Test

Manual test on chrome (could not reproduce it on FF in the first place)
