### PR TITLE
EZP-22813: Impossible to create users in IE11

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,14 +79,18 @@ Example:
                                         // will not trigger an auto submit
             action: 'url/to/post/the/form/content', // should answer in JSON
             interval: 30, // number of seconds between two submit attempts
-            trackUserInput: true // boolean, whether the component should try to
-                                 // submit the form if the user leaves a field
-                                 // and has made changes
+            trackUserInput: true, // boolean, whether the component should try to
+                                  // submit the form if the user leaves a field
+                                  // and has made changes
+            enabled: function () { return true; } // optional function to
+                                                  // disable autosave in some circumstances
             });
 
         as.on('init', function () {
             // init event
             // triggered when the component is initialized
+            // if the `enabled` function returns false, this event is not
+            // triggered
             // "this" is the Y.eZ.AutoSubmit instance
         });
 

--- a/design/admin/templates/content/edit/autosave.tpl
+++ b/design/admin/templates/content/edit/autosave.tpl
@@ -19,7 +19,19 @@ YUI(YUI3_config).use('ezautosubmit', 'ezcontentpreview', 'node-base', 'node-styl
             ignoreClass: 'no-autosave',
             action: {concat( 'ezjscore/call/ezautosave::savedraftpreview::', $object.id, '::', $edit_version, '::', $edit_language, '?ContentType=javascript' )|ezurl},
             interval: {ezini( 'AutosaveSettings', 'Interval', 'autosave.ini' )|int()},
-            trackUserInput: {cond( ezini( 'AutosaveSettings', 'TrackUserInput', 'autosave.ini')|eq( 'enabled' ), "true", "false" )}
+            trackUserInput: {cond( ezini( 'AutosaveSettings', 'TrackUserInput', 'autosave.ini')|eq( 'enabled' ), "true", "false" )},
+            enabled: function () {ldelim}
+
+                var ieDisableWithPassword = [{ezini( 'BrowserWorkarounds', 'IEDisableWithPassword', 'autosave.ini' )|implode( ', ')}];
+
+                if ( ieDisableWithPassword.indexOf(Y.UA.ie) !== -1 ) {ldelim}
+
+                    return (Y.one(this.conf.form).all("input[type=password]").size() == 0);
+                {rdelim}
+
+                return true;
+            {rdelim}
+
         {rdelim}),
         messages = {ldelim}
 

--- a/design/ezwebin/templates/content/edit/autosave.tpl
+++ b/design/ezwebin/templates/content/edit/autosave.tpl
@@ -9,7 +9,19 @@ YUI(YUI3_config).use('ezautosubmit', 'node-base', 'node-style', function (Y) {ld
             form: '#editform',
             action: {concat( 'ezjscore/call/ezautosave::savedraft::', $object.id, '::', $edit_version, '::', $edit_language, '?ContentType=javascript' )|ezurl},
             interval: {ezini( 'AutosaveSettings', 'Interval', 'autosave.ini' )|int()},
-            trackUserInput: {cond( ezini( 'AutosaveSettings', 'TrackUserInput', 'autosave.ini')|eq( 'enabled' ), "true", "false" )}
+            trackUserInput: {cond( ezini( 'AutosaveSettings', 'TrackUserInput', 'autosave.ini')|eq( 'enabled' ), "true", "false" )},
+            enabled: function () {ldelim}
+
+                var ieDisableWithPassword = [{ezini( 'BrowserWorkarounds', 'IEDisableWithPassword', 'autosave.ini' )|implode( ', ')}];
+
+                if ( ieDisableWithPassword.indexOf(Y.UA.ie) !== -1 ) {ldelim}
+
+                    return (Y.one(this.conf.form).all("input[type=password]").size() == 0);
+                {rdelim}
+
+                return true;
+            {rdelim}
+
         {rdelim}),
         messages = {ldelim}
 

--- a/design/standard/javascript/ezautosubmit.js
+++ b/design/standard/javascript/ezautosubmit.js
@@ -73,9 +73,12 @@ YUI(YUI3_config).add('ezautosubmit', function (Y) {
      *              - action String, the URI to POST the form
      *              - interval Integer, number of seconds between 2 auto submit attempts
      *              - trackUserInput Boolean, whether to auto submit the end user leave a form field
+     *              - enabled Function, optional function returning a boolean called when the page
+     *                is ready, allowing to disabled autosave in some circumstances
      */
     function eZAutoSubmit(conf) {
-        var that = this;
+        var that = this,
+            enableCheckFunc = conf.enabled || function () { return true; };
 
         this.conf = Y.merge(defaultConfig, conf);
         this.conf.interval = parseInt(this.conf.interval);
@@ -96,7 +99,10 @@ YUI(YUI3_config).add('ezautosubmit', function (Y) {
         this.ajaxSubscription = false;
 
         Y.on('domready', function () {
-            that.fire('init');
+            that.isEnabled = enableCheckFunc.call(that);
+            if ( that.isEnabled ) {
+                that.fire('init');
+            }
         });
 
         Y.on('autosubmit:forcesave', function () {
@@ -118,6 +124,9 @@ YUI(YUI3_config).add('ezautosubmit', function (Y) {
             return;
         }
         Y.on('domready', function () {
+            if ( !that.isEnabled ) {
+                return;
+            }
             that.timer = Y.later(that.conf.interval * 1000, that, that.submit, [], true);
             that.started = true;
             that.state = serializeForm(that.conf.form, that.conf.ignoreClass);

--- a/settings/autosave.ini.append.php
+++ b/settings/autosave.ini.append.php
@@ -15,4 +15,15 @@ HideStoreDraftButton=enabled
 # whether to hide the preview link
 HidePreviewLink=disabled
 
+[BrowserWorkarounds]
+# Disable autosave in IE (11 for now) when the form has a password field.
+# This is because by default IE 11 is not able to post a form to an iframe
+# when giving the focus to a password field...
+# It's possible to change this behaviour by unchecking the "Enable Protected
+# Mode" options in the security settings of IE11 or by putting the eZ Publish
+# website in a zone where this option is disabled.
+# See https://jira.ez.no/browse/EZP-22813
+IEDisableWithPassword[]
+IEDisableWithPassword[]=11
+
 */ ?>


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-22813
# Description

In IE11 (with the default settings) has a very weird behavior: if you start filling a form (with ezautosave enabled) and you give the focus to a password field the form will not be submitted to the iframe (referenced in the `target` 
form attribute to allow upload while having an _ajax-like_ request).

This does not happen if the _Enable Protected Mode_ setting is disabled for the security zone used by IE but by default any web site is in a zone where this _protected mode_ is on...

As a result, this patch is more a workaround than an actual fix since it adds a setting to disable autosave in forms having a password field for some IE versions but unfortunately there's no way to fix that properly... 
# Tests

manual tests
