### PR TITLE
EZP-23458: disable autosave preview when Preview link is hidden.

### DIFF
--- a/design/admin/templates/content/edit/autosave.tpl
+++ b/design/admin/templates/content/edit/autosave.tpl
@@ -9,6 +9,11 @@ display:none;
 <![endif]-->
 {/literal}
 {ezscript_require( array( 'ezjsc::yui3', 'ezautosubmit.js' ) )}
+{if ezini( 'AutosaveSettings', 'HidePreviewLink', 'autosave.ini' )|eq( 'enabled' ) }
+{def $as_ajax_request = 'ezjscore/call/ezautosave::savedraft' }
+{else}
+{def $as_ajax_request = 'ezjscore/call/ezautosave::savedraftpreview' }
+{/if}
 <script type="text/javascript">
 
 YUI(YUI3_config).use('ezautosubmit', 'ezcontentpreview', 'node-base', 'node-style', function (Y) {ldelim}
@@ -17,7 +22,7 @@ YUI(YUI3_config).use('ezautosubmit', 'ezcontentpreview', 'node-base', 'node-styl
 
             form: '#editform',
             ignoreClass: 'no-autosave',
-            action: {concat( 'ezjscore/call/ezautosave::savedraftpreview::', $object.id, '::', $edit_version, '::', $edit_language, '?ContentType=javascript' )|ezurl},
+            action: {concat( $as_ajax_request, '::', $object.id, '::', $edit_version, '::', $edit_language, '?ContentType=javascript' )|ezurl},
             interval: {ezini( 'AutosaveSettings', 'Interval', 'autosave.ini' )|int()},
             trackUserInput: {cond( ezini( 'AutosaveSettings', 'TrackUserInput', 'autosave.ini')|eq( 'enabled' ), "true", "false" )},
             enabled: function () {ldelim}


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-23458

When `HidePreviewLink` setting is `enabled` in ezautosave , there is no reason to fetch preview content and store it on the iframe.
This modifies the ajax request used for autosave to `savedraft` in this case, which does not return any content.
